### PR TITLE
Improve site design: typography, colors, polish

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
+
 export interface Props {
   title: string;
   description?: string;
@@ -17,6 +19,7 @@ const pageTitle = title === 'Home' ? 'Kacper Cygan' : `${title} | Kacper Cygan`;
     <meta name="author" content="Kacper Cygan" />
     <title>{pageTitle}</title>
     <link rel="icon" type="image/jpeg" href="/images/avatar.JPG" />
+    <ViewTransitions />
   </head>
   <body>
     <header>
@@ -33,7 +36,7 @@ const pageTitle = title === 'Home' ? 'Kacper Cygan' : `${title} | Kacper Cygan`;
 </html>
 
 <style is:global>
-  @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&family=Source+Serif+4:wght@600;700&display=swap');
 
   *, *::before, *::after { box-sizing: border-box; }
 
@@ -46,6 +49,7 @@ const pageTitle = title === 'Home' ? 'Kacper Cygan' : `${title} | Kacper Cygan`;
     margin: 0;
     font-family: "Nunito", "Avenir", "Helvetica", sans-serif;
     color: hsla(0, 0%, 0%, 0.8);
+    background-color: #faf9f7;
     font-weight: normal;
     word-wrap: break-word;
     font-kerning: normal;
@@ -95,24 +99,41 @@ const pageTitle = title === 'Home' ? 'Kacper Cygan' : `${title} | Kacper Cygan`;
 
   a { font-style: normal; color: hsla(0, 0%, 0%, 0.8); }
 
-  h1 { font-size: 2.25rem; font-weight: bold; line-height: 1.1; margin: 0 0 1.45rem; text-rendering: optimizeLegibility; }
-  h2 { font-size: 1.62671rem; font-weight: bold; line-height: 1.1; margin: 0 0 1.45rem; text-rendering: optimizeLegibility; }
-  h3 { font-size: 1.38316rem; font-weight: bold; line-height: 1.1; margin: 0 0 1.45rem; text-rendering: optimizeLegibility; }
-  h4, h5, h6 { font-weight: bold; line-height: 1.1; margin: 0 0 1.45rem; text-rendering: optimizeLegibility; }
+  h1, h2, h3, h4, h5, h6 {
+    font-family: "Source Serif 4", georgia, serif;
+    font-weight: 700;
+    line-height: 1.1;
+    margin: 0 0 1.45rem;
+    text-rendering: optimizeLegibility;
+    letter-spacing: -0.02em;
+  }
+
+  h1 { font-size: 2.25rem; }
+  h2 { font-size: 1.62671rem; }
+  h3 { font-size: 1.38316rem; }
 
   p { margin: 0 0 1.45rem; }
   ul, ol { margin: 0 0 1.45rem 1.45rem; list-style-position: outside; }
   li { margin-bottom: calc(1.45rem / 2); }
   li > ol, li > ul { margin-left: 1.45rem; margin-top: calc(1.45rem / 2); margin-bottom: calc(1.45rem / 2); }
-  blockquote { margin: 0 1.45rem 1.45rem; }
+
+  blockquote {
+    margin: 0 0 1.45rem;
+    padding: 0.1rem 1.45rem;
+    border-left: 3px solid hsl(150, 25%, 65%);
+    font-style: italic;
+    color: hsla(0, 0%, 0%, 0.65);
+  }
+
   img { max-width: 100%; border-style: none; }
-  hr { margin: 0 0 calc(1.45rem - 1px); background: hsla(0, 0%, 0%, 0.2); border: none; height: 1px; }
+  hr { margin: 0 0 calc(1.45rem - 1px); background: hsla(0, 0%, 0%, 0.12); border: none; height: 1px; }
   b, strong { font-weight: bold; }
 
   pre {
     margin: 0 0 1.45rem;
     font-size: 0.85rem;
     border-radius: 6px;
+    border-left: 3px solid hsl(150, 25%, 65%);
     overflow: auto;
     word-wrap: normal;
     padding: 1.2rem 1.45rem;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,8 +5,8 @@ import Layout from '../layouts/Layout.astro';
 <Layout title="404 — Not Found">
   <div class="content">
     <h1>404</h1>
-    <p>This page doesn't exist.</p>
-    <a href="/">Go home</a>
+    <p class="message">Nothing here. Maybe it never was.</p>
+    <a href="/">Take me home</a>
   </div>
 </Layout>
 
@@ -14,16 +14,28 @@ import Layout from '../layouts/Layout.astro';
   .content {
     margin: 0 auto;
     max-width: 860px;
-    padding: 4rem 1.0875rem;
+    padding: 6rem 1.0875rem;
     text-align: center;
+  }
+
+  h1 {
+    font-size: 5rem;
+    margin-bottom: 0.5rem;
+    color: hsla(0, 0%, 0%, 0.15);
+  }
+
+  .message {
+    color: hsla(0, 0%, 0%, 0.5);
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
   }
 
   a {
     text-decoration: none;
     color: inherit;
     background-image: linear-gradient(
-      rgba(255, 250, 150, 0.8),
-      rgba(255, 250, 150, 0.8)
+      hsla(150, 40%, 75%, 0.7),
+      hsla(150, 40%, 75%, 0.7)
     );
     background-repeat: no-repeat;
     background-size: 100% 0.2em;

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -26,8 +26,10 @@ function formatDate(date: Date) {
 
 <Layout title={post.data.title} description={post.data.description}>
   <div class="content">
+    <a href="/blog" class="back-link">&larr; Back to blog</a>
     <h1 class="post-title">{post.data.title}</h1>
     <p class="meta">{formatDate(post.data.date)} — {stats.text}</p>
+    <hr class="separator" />
     <div class="prose">
       <Content />
     </div>
@@ -41,6 +43,19 @@ function formatDate(date: Date) {
     padding: 1.45rem 1.0875rem;
   }
 
+  .back-link {
+    display: inline-block;
+    text-decoration: none;
+    color: hsla(0, 0%, 0%, 0.5);
+    font-size: 0.9rem;
+    margin-bottom: 1.5rem;
+    transition: color 0.2s ease;
+  }
+
+  .back-link:hover {
+    color: hsla(0, 0%, 0%, 0.8);
+  }
+
   .post-title {
     display: inline;
     border-radius: 1em 0 1em 0;
@@ -52,8 +67,13 @@ function formatDate(date: Date) {
     font-size: 1rem;
   }
 
+  .separator {
+    margin: 1.5rem 0;
+    background: hsla(0, 0%, 0%, 0.08);
+  }
+
   .prose {
-    margin-top: 2rem;
+    max-width: 680px;
   }
 
   .prose :global(a) {
@@ -61,8 +81,8 @@ function formatDate(date: Date) {
     position: relative;
     color: inherit;
     background-image: linear-gradient(
-      rgba(255, 250, 150, 0.8),
-      rgba(255, 250, 150, 0.8)
+      hsla(150, 40%, 75%, 0.7),
+      hsla(150, 40%, 75%, 0.7)
     );
     background-repeat: no-repeat;
     background-size: 100% 0.2em;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -43,7 +43,7 @@ function formatDate(date: Date) {
   }
 
   .post {
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
   }
 
   .post a {
@@ -57,9 +57,9 @@ function formatDate(date: Date) {
     border-radius: 1em 0 1em 0;
     background-image: linear-gradient(
       -100deg,
-      rgba(255, 250, 150, 0.15),
-      rgba(255, 250, 150, 0.8) 100%,
-      rgba(255, 250, 150, 0.25)
+      hsla(150, 40%, 75%, 0.15),
+      hsla(150, 40%, 75%, 0.7) 100%,
+      hsla(150, 40%, 75%, 0.25)
     );
     margin-bottom: 0.4rem;
     line-height: 1.4;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,19 +22,25 @@ import Layout from '../layouts/Layout.astro';
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 78vh;
+    min-height: 82vh;
   }
 
   .container {
     text-align: center;
+    animation: fadeIn 0.4s ease-out;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
   }
 
   .avatar {
-    height: 150px;
-    width: 150px;
+    height: 180px;
+    width: 180px;
     border-radius: 100%;
     object-fit: cover;
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
   }
 
   h1 {
@@ -44,8 +50,8 @@ import Layout from '../layouts/Layout.astro';
 
   .subtitle {
     font-size: 1.4rem;
-    margin-bottom: 1rem;
-    color: hsla(0, 0%, 0%, 0.6);
+    margin-bottom: 1.25rem;
+    color: hsla(0, 0%, 0%, 0.5);
   }
 
   p {
@@ -58,8 +64,8 @@ import Layout from '../layouts/Layout.astro';
     color: inherit;
     position: relative;
     background-image: linear-gradient(
-      rgba(255, 250, 150, 0.8),
-      rgba(255, 250, 150, 0.8)
+      hsla(150, 40%, 75%, 0.7),
+      hsla(150, 40%, 75%, 0.7)
     );
     background-repeat: no-repeat;
     background-size: 100% 0.2em;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&family=Source+Serif+4:wght@600;700&display=swap');
 
 /* Reset & base */
 *, *::before, *::after {
@@ -14,6 +14,7 @@ body {
   margin: 0;
   font-family: "Nunito", "Avenir", "Helvetica", sans-serif;
   color: hsla(0, 0%, 0%, 0.8);
+  background-color: #faf9f7;
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;
@@ -68,36 +69,18 @@ a {
   color: hsla(0, 0%, 0%, 0.8);
 }
 
-h1 {
-  font-size: 2.25rem;
-  font-weight: bold;
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Source Serif 4", georgia, serif;
+  font-weight: 700;
   line-height: 1.1;
   margin: 0 0 1.45rem;
   text-rendering: optimizeLegibility;
+  letter-spacing: -0.02em;
 }
 
-h2 {
-  font-size: 1.62671rem;
-  font-weight: bold;
-  line-height: 1.1;
-  margin: 0 0 1.45rem;
-  text-rendering: optimizeLegibility;
-}
-
-h3 {
-  font-size: 1.38316rem;
-  font-weight: bold;
-  line-height: 1.1;
-  margin: 0 0 1.45rem;
-  text-rendering: optimizeLegibility;
-}
-
-h4, h5, h6 {
-  font-weight: bold;
-  line-height: 1.1;
-  margin: 0 0 1.45rem;
-  text-rendering: optimizeLegibility;
-}
+h1 { font-size: 2.25rem; }
+h2 { font-size: 1.62671rem; }
+h3 { font-size: 1.38316rem; }
 
 p {
   margin: 0 0 1.45rem;
@@ -119,7 +102,11 @@ li > ol, li > ul {
 }
 
 blockquote {
-  margin: 0 1.45rem 1.45rem;
+  margin: 0 0 1.45rem;
+  padding: 0.1rem 1.45rem;
+  border-left: 3px solid hsl(150, 25%, 65%);
+  font-style: italic;
+  color: hsla(0, 0%, 0%, 0.65);
 }
 
 img {
@@ -130,7 +117,7 @@ img {
 
 hr {
   margin: 0 0 calc(1.45rem - 1px);
-  background: hsla(0, 0%, 0%, 0.2);
+  background: hsla(0, 0%, 0%, 0.12);
   border: none;
   height: 1px;
 }
@@ -144,6 +131,7 @@ pre {
   font-size: 0.85rem;
   line-height: 1.42;
   border-radius: 6px;
+  border-left: 3px solid hsl(150, 25%, 65%);
   overflow: auto;
   word-wrap: normal;
   padding: 1.2rem 1.45rem;
@@ -169,6 +157,7 @@ pre code {
 /* Shiki code blocks */
 .astro-code {
   border-radius: 6px;
+  border-left: 3px solid hsl(150, 25%, 65%);
   padding: 1.2rem 1.45rem;
   margin-bottom: 1.45rem;
   overflow-x: auto;


### PR DESCRIPTION
- Add Source Serif 4 for headings (serif/sans-serif pairing)
- Warm background (#faf9f7) instead of pure white
- Swap yellow accent for sage green throughout
- Add View Transitions for smooth page navigation
- Bigger avatar (180px) with fade-in animation on landing
- Style blockquotes with left border + italic
- Add accent border on code blocks
- Tighter heading letter-spacing (-0.02em)
- Add back-to-blog link on post pages
- Narrower prose column (680px) for better readability
- Separator between post meta and body
- More spacing between blog list items
- Playful 404 page with large faded heading

https://claude.ai/code/session_01BdTrYFqB1TUybyN4zBPTip